### PR TITLE
Fix fluentd dependency

### DIFF
--- a/fluent-plugin-filter-base64-decode.gemspec
+++ b/fluent-plugin-filter-base64-decode.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency "fluentd", ">= 0.12"
+  gem.add_runtime_dependency "fluentd", ">= 0.14.0", "< 2"
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
This gem requires `fluent/plugin/filter`, this file does not exist in
Fluentd v0.12.x. So we cannot run this plugin with Fluentd v0.12.x.