### PR TITLE
Remove redundant condition

### DIFF
--- a/lib/fluent/plugin/filter_base64_decode.rb
+++ b/lib/fluent/plugin/filter_base64_decode.rb
@@ -24,5 +24,5 @@ module Fluent
       record
     end
 
-  end if defined?(Filter) # Support only >= v0.12
+  end
 end


### PR DESCRIPTION
Because this gem supports Fluentd v0.14 or later.
See also #2